### PR TITLE
add google-services.json to .gitignore, check out description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+app/google-services.json


### PR DESCRIPTION
Removing a committed filled from all git commits
Since you accidentally committed and pushed the google-services.json file to git, you must remove it from the git history. Here are the steps:

Delete the file from the repository:
git rm app/google-services.json git commit -m "Remove google-services.json" git push

Remove the file from the git history. You need to rewrite all commits after the commit where you added this file: git filter-branch --force --index-filter \ "git rm --cached --ignore-unmatch app/google-services.json" \ --prune-empty --tag-name-filter cat -- --all

Force push the cleaned-up history to overwrite the remote: git push origin --force --all

Ask anyone who pulled the bad history to run the following to overwrite their local repository: git fetch origin git reset --hard origin/main git gc --prune=now

This will remove the file from the repository and rewrite the git history to eliminate that file completely. Be very careful when rewriting public commit history.

In the future, make sure not to commit sensitive files like google-services.json. You can add it to .gitignore.